### PR TITLE
support dumping sequences of heap images

### DIFF
--- a/cfg/generate_mask_dataset_test.yaml
+++ b/cfg/generate_mask_dataset_test.yaml
@@ -1,0 +1,22 @@
+num_states: 10                                      # Total number of states in dataset
+num_images_per_state: 2                             # Number of images per state
+states_per_flush: 10                                # Number of states before writing tensors (if saving tensors)
+states_per_garbage_collect: 10                      # Number of states before garbage collection (due to pybullet memory issues)
+log_rate: 1                                         # Rate at which to log dataset generation information
+debug: 0                                            # Debug flag to see physics simulation, set random seed
+urdf_cache_dir: ../objects/urdf/cache/        # Directory to store URDF files for meshes
+
+!include partials/states_test.yaml
+!include partials/mask_dataset.yaml
+
+images:
+  color: 1
+  depth: 1
+  modal: 1
+  amodal: 1
+  semantic: 1
+
+vis:                                                # Visualization flags for viewing each state and generated images
+  state: 0
+  obs: 0
+  semantic: 0

--- a/cfg/partials/states_test.yaml
+++ b/cfg/partials/states_test.yaml
@@ -1,0 +1,99 @@
+state_space:
+  heap:
+    workspace:          # Workspace boundaries define what region the objects can be dropped in
+      min:              # x,y,z
+        - -0.2
+        - -0.25
+        - 0.0
+      max:              # x,y,z
+        - 0.2
+        - 0.25
+        - 0.3
+
+      objects:          # static workspace objects
+        bin:
+          mesh_filename: data/bin/bin.obj
+          pose_filename: data/bin/bin_pose.tf
+
+        plane:
+          mesh_filename: data/plane/plane.obj
+          pose_filename: data/plane/plane_pose.tf
+
+    center:             # x,y coordinates for the center of the workspace (where the center dropping point can be)
+      min:              # This is a uniform random variable from "min" to "max"
+        - -0.1
+        - -0.1
+      max:
+        - 0.1
+        - 0.1
+
+    mean_objs: 7.5        # Poisson dist mean for number of objects in each heap
+    min_objs: 2         # Min objs in each heap
+    max_objs: 10        # Max objs in each heap
+    replace: 0          # Sample objects with replacement?
+    max_obj_diam: 0.3   # Max diameter of object to be dropped (otherwise it will be skipped)
+    drop_height: 0.2
+
+    # Dynamic sim parameters
+    max_settle_steps: 500
+    mag_v_thresh: 0.005
+    mag_w_thresh: 0.1
+
+    objects:
+      mesh_dir: ../objects/meshes/    # Directory containing meshes to be dropped
+      num_objects: 50                       # Number of objects in dataset (test and train)
+      train_pct: 0.8                        # Percentage of objects to be designated as train
+      object_keys:                          # Folders containing meshes
+        ycb: all                            # all -> all meshes in folder. Can also specify list of mesh names
+        3dnet: all
+        kit: all
+        mini_dexnet: all
+        other: all
+        thingiverse: all
+
+      planar_translation:                   # Amount of translation around the center point to drop each object
+        min:                                # Uniform random variable
+          - -0.025
+          - -0.025
+        max:
+          - 0.025
+          - 0.025
+
+      center_of_mass:                       # Std deviation for normal perturbation of object center of mass
+        sigma: 0.0
+
+      density: 4000                         # Fixed density for each object
+
+  camera:
+    name: camera
+
+    # Image size
+    im_width: 512
+    im_height: 384
+
+    focal_length:                           # Camera intrinsics: fx and fy
+      min: 535                              # Sampled uniformly over the given range
+      max: 560
+    delta_optical_center:                   # Camera intrinsics: cx and cy
+      min: -2.5                             # Sampled uniformly over the given range
+      max: 2.5
+
+    x:                                      # Variation in x position and y position
+      min: -0.05                            # Sampled uniformly over the given range
+      max: 0.05
+    y:
+      min: -0.05
+      max: 0.05
+
+    radius:                                 # Uniform random variable for camera distance
+      min: 0.7
+      max: 0.9
+    elevation:                              # Uniform random variable for camera elevation
+      min: 0.01
+      max: 10
+    azimuth:                                # Uniform random variable for camera azimuth
+      min: 0
+      max: 360
+    roll:                                   # Uniform random variable for camera roll
+      min: -10
+      max: 10

--- a/sd_maskrcnn/envs/bin_heap_env.py
+++ b/sd_maskrcnn/envs/bin_heap_env.py
@@ -35,7 +35,7 @@ class BinHeapEnv(gym.Env):
     """ OpenAI Gym-style environment for creating object heaps in a bin. """
 
     def __init__(self, config):
-        
+
         self._config = config
 
         # read subconfigs
@@ -53,7 +53,7 @@ class BinHeapEnv(gym.Env):
 
     @property
     def state(self):
-        return self._state  
+        return self._state
 
     @property
     def camera(self):
@@ -84,10 +84,10 @@ class BinHeapEnv(gym.Env):
         state = self._state_space.sample()
         self._state = state.heap
         self._camera = state.camera
-    
+
     def _update_scene(self):
         # update camera
-        camera = IntrinsicsCamera(self.camera.intrinsics.fx, self.camera.intrinsics.fy, 
+        camera = IntrinsicsCamera(self.camera.intrinsics.fx, self.camera.intrinsics.fy,
                                   self.camera.intrinsics.cx, self.camera.intrinsics.cy)
         cn = next(iter(self._scene.get_nodes(name=self.camera.frame)))
         cn.camera = camera
@@ -121,7 +121,7 @@ class BinHeapEnv(gym.Env):
         scene = Scene()
 
         # setup camera
-        camera = IntrinsicsCamera(self.camera.intrinsics.fx, self.camera.intrinsics.fy, 
+        camera = IntrinsicsCamera(self.camera.intrinsics.fx, self.camera.intrinsics.fy,
                                   self.camera.intrinsics.cx, self.camera.intrinsics.cy)
         pose_m = self.camera.pose.matrix.copy()
         pose_m[:,1:3] *= -1.0
@@ -161,7 +161,7 @@ class BinHeapEnv(gym.Env):
         Useful for generating image data for multiple camera views
         """
         self._camera = self.state_space.camera.sample()
-        self._update_scene()     
+        self._update_scene()
 
     def reset(self):
         """ Reset the environment. """
@@ -187,9 +187,11 @@ class BinHeapEnv(gym.Env):
         image = renderer.render(self._scene, flags=flags)
         renderer.delete()
         return image
-    
+
     def render_segmentation_images(self):
         """Renders segmentation masks (modal and amodal) for each object in the state.
+        Also returns a list of object keys, where the i-th key corresponds with the i-th
+        returned amodal and modal mask.
         """
 
         full_depth = self.render_camera_image(color=False)
@@ -216,12 +218,12 @@ class BinHeapEnv(gym.Env):
             node.mesh.is_visible = False
 
         renderer.delete()
-        
+
         # Show all meshes
         for mn in self._scene.mesh_nodes:
             mn.mesh.is_visible = True
 
-        return amodal_data, modal_data
+        return amodal_data, modal_data, self.obj_keys
 
     def _create_raymond_lights(self):
         thetas = np.pi * np.array([1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0])

--- a/sd_maskrcnn/envs/bin_heap_env.py
+++ b/sd_maskrcnn/envs/bin_heap_env.py
@@ -190,8 +190,6 @@ class BinHeapEnv(gym.Env):
 
     def render_segmentation_images(self):
         """Renders segmentation masks (modal and amodal) for each object in the state.
-        Also returns a list of object keys, where the i-th key corresponds with the i-th
-        returned amodal and modal mask.
         """
 
         full_depth = self.render_camera_image(color=False)
@@ -223,7 +221,7 @@ class BinHeapEnv(gym.Env):
         for mn in self._scene.mesh_nodes:
             mn.mesh.is_visible = True
 
-        return amodal_data, modal_data, self.obj_keys
+        return amodal_data, modal_data
 
     def _create_raymond_lights(self):
         thetas = np.pi * np.array([1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0])

--- a/tools/generate_mask_dataset.py
+++ b/tools/generate_mask_dataset.py
@@ -324,7 +324,7 @@ def generate_segmask_dataset(output_dataset_path, config, save_tensors=True, war
                     env.state.obj_states = [x for x in env.state.obj_states if x.key != obj_key]
                     node = list(env._scene.get_nodes(name=obj_key))[0]
                     env._scene.remove_node(node)
-                else:    
+                else:
                     env.reset()
                 state = env.state
                 split = state.metadata['split']
@@ -395,7 +395,7 @@ def generate_segmask_dataset(output_dataset_path, config, save_tensors=True, war
 
                     if image_config['modal'] or image_config['amodal'] or image_config['semantic']:
                         # render segmasks
-                        amodal_segmasks, modal_segmasks, heap_obj_keys = env.render_segmentation_images()
+                        amodal_segmasks, modal_segmasks = env.render_segmentation_images()
 
                         # retrieve segmask data
                         modal_segmask_arr = np.iinfo(np.uint8).max * np.ones([im_height,
@@ -480,7 +480,7 @@ def generate_segmask_dataset(output_dataset_path, config, save_tensors=True, war
 
                     # record heap object keys
                     heap_obj_keys_dict['image_{:06d}.png'.format(
-                        num_images_per_state*state_id + k)] = heap_obj_keys
+                        num_images_per_state*state_id + k)] = env.state.obj_keys
 
                     # Save split
                     if split == TRAIN_ID:

--- a/tools/generate_single_obj_dataset.py
+++ b/tools/generate_single_obj_dataset.py
@@ -1,0 +1,83 @@
+"""
+Generates a dataset of individual object images in bins.
+"""
+
+import argparse
+import gc
+import numpy as np
+import os
+import json
+import shutil
+import time
+import traceback
+import matplotlib.pyplot as plt
+
+from autolab_core import TensorDataset, YamlConfig, Logger
+import autolab_core.utils as utils
+from perception import DepthImage, GrayscaleImage, BinaryImage, ColorImage
+
+from sd_maskrcnn.envs import BinHeapEnv
+from sd_maskrcnn.envs.constants import *
+
+from generate_mask_dataset import generate_segmask_dataset
+
+SEED = 744
+
+# set up logger
+logger = Logger.get_logger('tools/generate_single_obj_dataset.py')
+
+
+if __name__ == '__main__':
+    # parse args
+    parser = argparse.ArgumentParser(description='Generate a dataset of single-object target images for a SD Mask R-CNN target branch')
+    parser.add_argument('output_dataset_path', type=str, default=None, help='directory to store a dataset containing the images')
+
+    args = parser.parse_args()
+    output_dataset_path = args.output_dataset_path
+    save_tensors = False
+    warm_start = False
+
+    # handle config filename
+    config_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '..',
+                                   'cfg_target/generate_mask_dataset.yaml')
+
+    # turn relative paths absolute
+    if not os.path.isabs(config_filename):
+        config_filename = os.path.join(os.getcwd(), config_filename)
+
+    # create dataset root directory
+    # (will contain an actual dataset dir per each mesh)
+    if not os.path.exists(output_dataset_path):
+        os.mkdir(output_dataset_path)
+
+    # open config file
+    config = YamlConfig(config_filename)
+
+    # get list of object names
+    mesh_dir = config['state_space']['heap']['objects']['mesh_dir']
+    mesh_list = [] # (dataset_name, file_name)
+
+    for root, dirs, files in os.walk(mesh_dir):
+        dataset_name = os.path.basename(root)
+        for f in files:
+            mesh_name, ext = os.path.splitext(f)
+            mesh_list.append((dataset_name, mesh_name))
+
+    # generate dataset
+    generation_start = time.time()
+
+    for dataset_name, mesh_name in mesh_list:
+        print('Generating images for', mesh_name, 'in', dataset_name)
+        # new path per single mesh dataset
+        mesh_output_dataset_path = os.path.join(output_dataset_path, mesh_name)
+        # edit config to reflect
+        config['state_space']['heap']['objects']['object_keys'] = {
+            dataset_name: [mesh_name]
+        }
+        generate_segmask_dataset(mesh_output_dataset_path, config,
+                                 save_tensors=False, warm_start=False)
+
+    # log time
+    generation_stop = time.time()
+    logger.info('Mask dataset generation took %.3f sec' %(generation_stop-generation_start))


### PR DESCRIPTION
Changes generation script to dump sequences of images of a single heap.

Note that as of this change, a "state" in the config files refers to an initial heap state- producing 1000 states with 5 images per state will create 1000 heaps, and for each heap remove an object and take a picture until the heap is empty. 5 images per state mean that 5 images will be dumped per every object removal that occurs in the heap.